### PR TITLE
Change dotenv-linter installation way

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 FROM alpine:3.11
 
-ENV DOTENV_LINTER_VERSION v2.0.0
+ENV DOTENV_LINTER_VERSION v2.1.0
 ENV REVIEWDOG_VERSION v0.10.1
 
 SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
 RUN apk add --no-cache git
 RUN wget -q -O - https://raw.githubusercontent.com/dotenv-linter/dotenv-linter/master/install.sh | sh -s -- -b /usr/local/bin/ $DOTENV_LINTER_VERSION
-RUN wget -O - -q https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh | sh -s -- -b /usr/local/bin/ $REVIEWDOG_VERSION
+RUN wget -q -O - https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh | sh -s -- -b /usr/local/bin/ $REVIEWDOG_VERSION
 
 COPY entrypoint.sh /entrypoint.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,7 @@ ENV REVIEWDOG_VERSION v0.10.1
 
 SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
 RUN apk add --no-cache git
-RUN wget https://github.com/dotenv-linter/dotenv-linter/releases/download/$DOTENV_LINTER_VERSION/dotenv-linter-alpine-x86_64.tar.gz -O - -q | tar -xzf -
-RUN mv dotenv-linter /usr/local/bin/
+RUN wget -q -O - https://raw.githubusercontent.com/dotenv-linter/dotenv-linter/master/install.sh | sh -s -- -b /usr/local/bin/ $DOTENV_LINTER_VERSION
 RUN wget -O - -q https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh | sh -s -- -b /usr/local/bin/ $REVIEWDOG_VERSION
 
 COPY entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
Now we can use the uniform api to install the `reviewdog` and `dotenv-linter`! :relaxed: 